### PR TITLE
Kernel: Update kernel build routine for CM4 version

### DIFF
--- a/Code/patch/cm4/20230630/README.md
+++ b/Code/patch/cm4/20230630/README.md
@@ -1,69 +1,37 @@
-# Patch for uConsole CM4
+# uConsole CM4 kernel sources
+uConsole kernel is based on Raspberry Pi kernel sources:
+`https://github.com/raspberrypi/linux.git`
 
-based on `https://github.com/raspberrypi/linux.git`
-
-commit hash: 3a33f11c48572b9dd0fecac164b3990fc9234da8
-
-## Prepares
-
-ubuntu 22.04 with aarch64-linux-gnu-
-
-```
-sudo apt install -y build-essential gcc-aarch64-linux-gnu 
-```
-
-## Example process of compiling
-
-```
-cd
-git clone https://github.com/raspberrypi/linux.git
-
-cd linux
-
-wget https://raw.githubusercontent.com/clockworkpi/uConsole/master/Code/patch/cm4/20230630/0001-patch-cm4.patch
-
-git reset --hard 3a33f11c48572b9dd0fecac164b3990fc9234da8
-
-git apply 0001-patch-cm4.patch
+The current version is based on top of commit hash:
+`3a33f11c48572b9dd0fecac164b3990fc9234da8`
 
 
-KERNEL=kernel8 make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- bcm2711_defconfig
-KERNEL=kernel8 make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- -j2
+# Build
+Kernel build can be performed on Ubuntu 22.04 with aarch64 cross compilation.
+To automate this process `build-kernel.sh` script has been created.
+It will automatically install all needed dependencies on for kernel building
+both from RPi and Ubuntu guidelines.
 
-mkdir ./modules
+On top of the RPi kernel - uConsole specific patch is applied. It contains
+implementation of all required drivers like video driver for uConsole screen.
 
-rm -rf ./modules/*
+To automate build process on environmend different than Ubuntu 22.04 `run.sh`
+script has been created. It utilizes docker container for building the kernel
+using build script.
 
-INSTALL_MOD_PATH=./modules make modules_install
+Final results are located in `out` directory in the source tree.
 
 
-rm modules/lib/modules/*/build
-rm modules/lib/modules/*/source
+# Deploy
+To deploy build result use content of `out` directory and copy it over
+to the right locations on SD card. More you can find in official RPi guide:
+https://www.raspberrypi.com/documentation/computers/linux_kernel.html
 
-```
 
-## config.txt 
+# Kernel configuration
+In order to use compiled kernel8.img with CM4 in uConsole, we have to setup
+a `config.txt` configuration file. It contains various options which will be
+passed to runtime kernel for proper uConsole specific drivers initialization.
 
-In order to use compiled kernel8.img with CM4 in uConsole ,we have to setup a config.txt
-
-```
-disable_overscan=1
-dtparam=audio=on
-[pi4]
-max_framebuffers=2
-
-[all]
-ignore_lcd=1
-dtoverlay=dwc2,dr_mode=host
-dtoverlay=vc4-kms-v3d-pi4,cma-384
-dtoverlay=devterm-pmu
-dtoverlay=devterm-panel-uc
-dtoverlay=devterm-misc
-dtoverlay=audremap,pins_12_13
-
-dtparam=spi=on
-gpio=10=ip,np
-dtparam=ant2
-```
 
 

--- a/Code/patch/cm4/20230630/build-kernel.sh
+++ b/Code/patch/cm4/20230630/build-kernel.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+set -eox pipefail
+
+# Create working directory
+mkdir -p /uConsole
+cd /uConsole
+
+# Install dependencies
+apt update
+
+# Base kernel build dependencies
+apt install -y build-essential \
+               gcc-aarch64-linux-gnu \
+               linux-headers-generic
+
+# Install RPi kernel build dependencies
+# [https://www.raspberrypi.com/documentation/computers/linux_kernel.html]
+apt install -y git \
+               bc \
+               bison \
+               flex \
+               libssl-dev \
+               make \
+               libc6-dev \
+               libncurses5-dev \
+               crossbuild-essential-arm64
+
+# Other possible usefull dependencies suggested by Ubuntu kernel building guide
+# [https://wiki.ubuntu.com/Kernel/BuildYourOwnKernel]
+apt install -y libncurses-dev \
+               gawk \
+               openssl \
+               libssl-dev \
+               dkms \
+               libelf-dev \
+               libudev-dev \
+               libpci-dev \
+               libiberty-dev \
+               autoconf \
+               llvm
+
+# Clone Raspberry kernel sources
+if [ ! -d "linux" ] ; then
+    git clone https://github.com/raspberrypi/linux.git
+fi
+cd linux
+
+# Linux repo may be already cloned in previous run so we need to remove
+# any existing files modifications / applied patches
+git clean -f
+
+# Use specified source version
+git reset --hard 3a33f11c48572b9dd0fecac164b3990fc9234da8
+
+# Apply uConsole specific patch
+git apply ../0001-patch-cm4.patch
+
+# Config for Raspberry Pi 3, 3+, 4, 400 and Zero 2 W, and Raspberry Pi
+# Compute Modules 3, 3+ and 4 default 64-bit build configuration:
+# - bcm2711_defconfig
+# - kernel8
+#
+# KERNEL=kernel8 make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- bcm2711_defconfig
+# KERNEL=kernel8 make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- -j4
+#
+# [https://www.raspberrypi.com/documentation/computers/linux_kernel.html]
+
+export KERNEL=kernel8
+export ARCH=arm64
+export CROSS_COMPILE=aarch64-linux-gnu-
+
+# Generate .config file
+make bcm2711_defconfig
+
+# Build kernel
+make -j4
+
+# Prepare placeholder for kernel modules
+mkdir -p ./modules
+rm -rf ./modules/*
+
+# Deploy modules in predefined location
+INSTALL_MOD_PATH=./modules make modules_install
+
+# Remove unused module files
+rm ./modules/lib/modules/*/build
+rm ./modules/lib/modules/*/source
+
+# Export build artifacts: kernel modules
+mkdir -p ../modules
+rm -rf ../modules/*
+
+cp -rav ./modules/* ../modules
+
+# Export build artifacts: kernel + device tree
+mkdir -p ../out
+rm -rf ../out/*
+mkdir -p ../out/overlays
+
+sudo cp arch/arm64/boot/Image ../out/$KERNEL.img
+sudo cp arch/arm64/boot/dts/broadcom/*.dtb ../out
+sudo cp arch/arm64/boot/dts/overlays/*.dtb* ../out/overlays/
+sudo cp arch/arm64/boot/dts/overlays/README ../out/overlays/
+

--- a/Code/patch/cm4/20230630/config.txt
+++ b/Code/patch/cm4/20230630/config.txt
@@ -1,0 +1,17 @@
+disable_overscan=1
+dtparam=audio=on
+[pi4]
+max_framebuffers=2
+
+[all]
+ignore_lcd=1
+dtoverlay=dwc2,dr_mode=host
+dtoverlay=vc4-kms-v3d-pi4,cma-384
+dtoverlay=devterm-pmu
+dtoverlay=devterm-panel-uc
+dtoverlay=devterm-misc
+dtoverlay=audremap,pins_12_13
+
+dtparam=spi=on
+gpio=10=ip,np
+dtparam=ant2

--- a/Code/patch/cm4/20230630/run.sh
+++ b/Code/patch/cm4/20230630/run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# To be able to build kernel modules container needs to run in privileged mode
+# [https://projectatomic.io/blog/2018/06/building-kernel-modules-with-podman/]
+
+# Spawn container and run build script
+docker run --rm --privileged -v ./:/uConsole ubuntu:22.04 /bin/bash /uConsole/build-kernel.sh
+
+# Start container to run build script manually
+# docker run -it --rm --privileged -v ./:/uConsole ubuntu:22.04


### PR DESCRIPTION
This change adds building scripts for an easier kernel build for CM4 module version of uConsole. From now one it can be done using Ubuntu 22.04 docker container on any Linux operating system.