### PR TITLE
Fix Battery Charge Current in PMU Devicetree Overlay

### DIFF
--- a/Code/patch/cm4/20230630/0001-patch-cm4.patch
+++ b/Code/patch/cm4/20230630/0001-patch-cm4.patch
@@ -363,7 +363,7 @@ index 000000000000..3ffc51b8fc2d
 +		__overlay__  {
 +			battery: battery@0 {
 +				compatible = "simple-battery";
-+				constant_charge_current_max_microamp = <2100000>;
++				constant-charge-current-max-microamp = <2100000>;
 +				voltage-min-design-microvolt = <3300000>;
 +			};
 +		};


### PR DESCRIPTION
This change fixes a small error in the devicetree overlay for the PMIC, which was causing battery charge current to be set to the default of 300mA rather than the desired 2.1A. 