### PR TITLE
Use select key to trigger wheel

### DIFF
--- a/Code/uconsole_keyboard/devterm.h
+++ b/Code/uconsole_keyboard/devterm.h
@@ -25,6 +25,7 @@ typedef struct keyboard_state{
   uint8_t layer;
   uint8_t prev_layer;
   uint8_t fn_on;
+  uint8_t select_on;
   uint16_t sf_on;//shift on
   
   uint8_t backlight;//0 1 2 3

--- a/Code/uconsole_keyboard/keymaps.ino
+++ b/Code/uconsole_keyboard/keymaps.ino
@@ -206,14 +206,18 @@ void keyboard_action(DEVTERM*dv, uint8_t row, uint8_t col, uint8_t mode) {
         k = ' ';
         if (mode == KEY_PRESSED) {
           dv->Keyboard->press(k);
+          dv->Keyboard_state.select_on = 1;
         } else if (mode == KEY_RELEASED) {
           keyboard_release(dv, addr, k);
+          dv->Keyboard_state.select_on = 0;
         }
       } else {
         if (mode == KEY_PRESSED) {
           dv->Joystick->button(9, mode);
+          dv->Keyboard_state.select_on = 1;
         } else {
           keyboard_release(dv, addr, k);
+          dv->Keyboard_state.select_on = 0;
         }
       }
       break;

--- a/Code/uconsole_keyboard/trackball.ino
+++ b/Code/uconsole_keyboard/trackball.ino
@@ -24,6 +24,7 @@ enum Axis: uint8_t {
   AXIS_NUM,
 };
 static TrackballMode lastMode;
+static bool asWheel = false;
 static int8_t distances[AXIS_NUM];
 static RateMeter rateMeter[AXIS_NUM];
 static Glider glider[AXIS_NUM];
@@ -39,6 +40,9 @@ static float rateToVelocityCurve(float input) {
 template<Axis AXIS, int8_t Direction >
 static void interrupt( ) {
   distances[AXIS] += Direction;
+  if (asWheel) {
+    return;
+  }
   rateMeter[AXIS].onInterrupt();
   glider[AXIS].setDirection(Direction);
 
@@ -69,7 +73,9 @@ void trackball_task(DEVTERM*dv) {
   noInterrupts();
   //const auto mode = dv->state->moveTrackball();
   //https://forum.clockworkpi.com/t/uconsole-trackball-as-scrolling-wheel-temporary-solution/11032/3
-  const auto mode = dv->Keyboard_state.fn_on == 0 ? TrackballMode::Mouse : TrackballMode::Wheel;
+  //const auto mode = dv->Keyboard_state.fn_on == 0 ? TrackballMode::Mouse : TrackballMode::Wheel;
+  asWheel = dv->Keyboard_state.select_on == 1;
+  const auto mode = asWheel ? TrackballMode::Wheel : TrackballMode::Mouse;
   if (lastMode != mode) {
     rateMeter[AXIS_X].expire();
     rateMeter[AXIS_Y].expire();

--- a/Code/uconsole_keyboard/uconsole_keyboard.ino
+++ b/Code/uconsole_keyboard/uconsole_keyboard.ino
@@ -41,6 +41,7 @@ void setup() {
   dev_term.Keyboard_state.layer = 0;
   dev_term.Keyboard_state.prev_layer = 0;
   dev_term.Keyboard_state.fn_on = 0;
+  dev_term.Keyboard_state.select_on = 0;
   dev_term.Keyboard_state.sf_on = 0;
   
   //dev_term.Keyboard_state.shift = 0;


### PR DESCRIPTION
- use select key as the wheel trigger
- when the select key is released, the cursor position remains

discussions: https://forum.clockworkpi.com/t/uconsole-trackball-as-scrolling-wheel-temporary-solution/11032/16?u=bsdelf