### PR TITLE
Mention necessary GND (ground) connection to enable flashing

### DIFF
--- a/wiki/How-to-use-keyboard-UART-port-to-flash-firmware.md
+++ b/wiki/How-to-use-keyboard-UART-port-to-flash-firmware.md
@@ -21,9 +21,10 @@ here is the process:
 3 is TX(PA9)   
 4 is RX(PA10)  
 
-
 ## 1st pin of UART on board
 ![7130803](https://github.com/user-attachments/assets/eeed0c0a-ea86-4496-b931-dcc074835eca)
+
+Do not forget to **also connect GND** (ground) between the fpc 6p connector and the serial-usb converter.
 
 ## Flashing command
 


### PR DESCRIPTION
The description has not been entirely clear abouth the necessity of a ground connection between the fpc connector and usb-serial device. 

While this is essential, it is not obvious from the pictures provided. This is hereby fixed.